### PR TITLE
Harden ssh

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,6 @@ gem 'inspec'
 gem 'json'
 
 group :test do
-    gem 'rspec'
-    gem 'rubocop'
+  gem 'rspec'
+  gem 'rubocop'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
-gem 'inspec'
 gem 'awesome_print'
 gem 'discourse_api', '~> 0.20.0'
+gem 'inspec'
 gem 'json'
 
 group :test do

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-[![Build Status](https://travis-ci.org/EGI-Foundation/community.egi.eu.svg?branch=master)](https://travis-ci.org/EGI-Foundation/community.egi.eu)
+[![Build Status](https://travis-ci.org/EGI-Foundation/community.egi.eu.svg?branch=master)](https://travis-ci.org/EGI-Foundation/community.egi.eu) [![Maintainability](https://api.codeclimate.com/v1/badges/5f45caa8cebee239d58f/maintainability)](https://codeclimate.com/github/EGI-Foundation/community.egi.eu/maintainability)
 
 # EGI Community Forum
 
 This repository contains the code necessary to deliver the [EGI Commnuity Forum](https://community.egi.eu). This is a web forum based on [discourse](http://discourse.org)
 
-The repository is organised into Ansible playbook and configuration data for deploying the forum. The host is in the `forum` group in the inventory file. Tasks applied to this group pick up variables from the `forum.yml` file in `group_vars`, because that is how excellent Ansible is. 
+The repository is organised into Ansible playbook and configuration data for deploying the forum. The host is in the `forum` group in the inventory file. Tasks applied to this group pick up variables from the `vars/community.egi.eu.yml` file, because that is how excellent Ansible is.
 
 The playbook uses a single role - [AAROC.discourse-sso](https://github.com/AAROC/discourse-sso) however this role has dependencies. Before making or proposing changes to this role, please consider what the dependencies do to provide docker and nginx.
 
@@ -23,3 +23,4 @@ If all that is ok, run the playbook, or get your favourite CI tool to do it :
 ## Testing
 
 The [tests](tests/README.md) directory contains the tests that we expect the service, server and machine to pass.
+They contain tests for the ssh connection, nginx server config and some content.

--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ If you are the maintainer of the service, you need to run the playbook with the 
 
 If all that is ok, run the playbook, or get your favourite CI tool to do it : 
 `ansible-playook -i inventory community.egi.eu.yml`
+
+## Testing
+
+The [tests](tests/README.md) directory contains the tests that we expect the service, server and machine to pass.

--- a/community.egi.eu.yml
+++ b/community.egi.eu.yml
@@ -1,7 +1,14 @@
 ---
 # Ansible playbook to deploy and maintain the EGI community forum
 - hosts: forum
+  name: harden ssh
+  roles:
+    - {role: dev-sec.ssh-hardening, tags: ssh}
+
+- hosts: forum
   name: Provide certs
+  tags:
+    - ssl
   tasks:
     - name: Ensure SSL location is present
       file:
@@ -29,6 +36,7 @@
 
 - hosts: forum
   name: Deploy !
-  pre_tasks:
+  tags:
+    - discourse
   roles:
     - {role: AAROC.discourse-sso, launch: 'False'}

--- a/group_vars/forum.yml
+++ b/group_vars/forum.yml
@@ -1,4 +1,147 @@
 ---
+## SSH stuff
+# true if IPv6 is needed
+network_ipv6_enable: false              # sshd + ssh
+# true if sshd should be started and enabled
+ssh_server_enabled: true               # sshd
+# true if DNS resolutions are needed, look up the remote host name, defaults to false from 6.8, see: http://www.openssh.com/txt/release-6.8
+ssh_use_dns: false                      # sshd
+# true or value if compression is needed
+ssh_compression: false                  # sshd
+# For which components (client and server) to generate the configuration for. 
+# Can be useful when running against a client without an SSH server.
+ssh_client_hardening: true          # ssh
+ssh_server_hardening: true          # sshd
+# true if CBC for ciphers is required. 
+# This is usually only necessary, if older M2M mechanism need to communicate with SSH, that don't have any of the configured secure ciphers enabled. 
+# CBC is a weak alternative. 
+# Anything weaker should be avoided and is thus not available.
+ssh_client_cbc_required: false          # ssh
+ssh_server_cbc_required: false          # sshd
+# true if weaker HMAC mechanisms are required. 
+# This is usually only necessary, if older M2M mechanism need to communicate with SSH, that don't have any of the configured secure HMACs enabled.
+ssh_client_weak_hmac: false             # ssh
+ssh_server_weak_hmac: false             # sshd
+# true if weaker Key-Exchange (KEX) mechanisms are required. 
+# This is usually only necessary, if older M2M mechanism need to communicate with SSH, that don't have any of the configured secure KEXs enabled.
+ssh_client_weak_kex: false              # ssh
+ssh_server_weak_kex: false              # sshd
+# If true, password login is allowed
+ssh_client_password_login: false          # ssh
+ssh_server_password_login: false          # sshd
+# ports on which ssh-server should listen
+ssh_server_ports: ['22']      # sshd
+# port to which ssh-client should connect
+ssh_client_port: '22'         # ssh
+# one or more ip addresses, to which ssh-server should listen to. 
+# Default is empty, but should be configured for security reasons!
+ssh_listen_to: ['0.0.0.0']    # sshd
+# Host keys to look for when starting sshd.
+ssh_host_key_files: []  # sshd
+# Specifies  the  maximum  number  of authentication attempts permitted per connection.  
+# Once the number of failures reaches half this value, additional failures are logged.
+ssh_max_auth_retries: 2
+ssh_client_alive_interval: 600          # sshd
+ssh_client_alive_count: 3               # sshd
+# Allow SSH Tunnels
+ssh_permit_tunnel: false
+ssh_remote_hosts: []
+# false to disable root login altogether. Set to true to allow root to login via key-based mechanism.
+ssh_allow_root_with_key: true          # sshd
+# false to disable TCP Forwarding. Set to true to allow TCP Forwarding.
+ssh_allow_tcp_forwarding: false         # sshd
+# false to disable binding forwarded ports to non-loopback addresses. Set to true to force binding on wildcard address.
+# Set to 'clientspecified' to allow the client to specify which address to bind to.
+ssh_gateway_ports: false                # sshd
+# false to disable Agent Forwarding. Set to true to allow Agent Forwarding.
+ssh_allow_agent_forwarding: true       # sshd
+# false to disable pam authentication.
+ssh_use_pam: true      # sshd
+# false to disable google 2fa authentication
+ssh_google_auth: false # sshd
+# if specified, login is disallowed for user names that match one of the patterns.
+ssh_deny_users: ''      # sshd
+# if specified, login is allowed only for user names that match one of the patterns.
+ssh_allow_users: ''      # sshd
+# if specified, login is disallowed for users whose primary group or supplementary group list matches one of the patterns.
+ssh_deny_groups: ''      # sshd
+# if specified, login is allowed only for users whose primary group or supplementary group list matches one of the patterns.
+ssh_allow_groups: ''      # sshd
+# change default file that contains the public keys that can be used for user authentication.
+ssh_authorized_keys_file: ''      # sshd
+# false to disable printing of the MOTD
+ssh_print_motd: false      # sshd
+# false to disable display of last login information
+ssh_print_last_log: false    # sshd
+# false to disable serving /etc/ssh/banner.txt before authentication is allowed
+ssh_banner: false # sshd
+# false to disable distribution version leakage during initial protocol handshake
+ssh_print_debian_banner: false # sshd (Debian OS family only)
+# true to enable sftp configuration
+sftp_enabled: false
+# change default sftp chroot location
+sftp_chroot_dir: /home/%u
+# enable experimental client roaming
+ssh_client_roaming: false
+# list of hashes (containing user and rules) to generate Match User blocks for.
+ssh_server_match_user: false            # sshd
+# list of hashes (containing group and rules) to generate Match Group blocks for.
+ssh_server_match_group: false           # sshd
+ssh_server_permit_environment_vars: false
+ssh_ps53: 'yes'
+ssh_ps59: 'sandbox'
+ssh_macs: []
+ssh_ciphers: []
+ssh_kex: []
+ssh_macs_53_default:
+  - hmac-ripemd160
+  - hmac-sha1
+ssh_macs_59_default:
+  - hmac-sha2-512
+  - hmac-sha2-256
+  - hmac-ripemd160
+ssh_macs_59_weak: "{{ ssh_macs_59_default + ['hmac-sha1'] }}"
+ssh_macs_66_default:
+  - hmac-sha2-512-etm@openssh.com
+  - hmac-sha2-256-etm@openssh.com
+  - umac-128-etm@openssh.com
+  - hmac-sha2-512
+  - hmac-sha2-256
+ssh_macs_76_default:
+  - hmac-sha2-512-etm@openssh.com
+  - hmac-sha2-256-etm@openssh.com
+  - umac-128-etm@openssh.com
+  - hmac-sha2-512
+  - hmac-sha2-256
+ssh_macs_66_weak: "{{ ssh_macs_66_default + ['hmac-sha1'] }}"
+ssh_ciphers_53_default:
+  - aes256-ctr
+  - aes192-ctr
+  - aes128-ctr
+ssh_ciphers_53_weak: "{{ ssh_ciphers_53_default + ['aes256-cbc', 'aes192-cbc', 'aes128-cbc'] }}"
+ssh_ciphers_66_default:
+  - chacha20-poly1305@openssh.com
+  - aes256-gcm@openssh.com
+  - aes128-gcm@openssh.com
+  - aes256-ctr
+  - aes192-ctr
+  - aes128-ctr
+ssh_ciphers_66_weak: "{{ ssh_ciphers_66_default + ['aes256-cbc', 'aes192-cbc', 'aes128-cbc'] }}"
+ssh_kex_59_default:
+  - diffie-hellman-group-exchange-sha256
+ssh_kex_59_weak: "{{ ssh_kex_59_default + ['diffie-hellman-group14-sha1', 'diffie-hellman-group-exchange-sha1', 'diffie-hellman-group1-sha1'] }}"
+ssh_kex_66_default:
+  - curve25519-sha256@libssh.org
+  - diffie-hellman-group-exchange-sha256
+ssh_kex_66_weak: "{{ ssh_kex_66_default + ['diffie-hellman-group14-sha1', 'diffie-hellman-group-exchange-sha1', 'diffie-hellman-group1-sha1'] }}"
+# directory where to store ssh_password policy
+ssh_custom_selinux_dir: '/etc/selinux/local-policies'
+sshd_moduli_minimum: 2048
+# disable ChallengeResponseAuthentication
+ssh_challengeresponseauthentication: false
+# a list of public keys that are never accepted by the ssh server
+ssh_server_revoked_keys: []
+
 ## NGINX stuff
 # Love https://mozilla.github.io/server-side-tls/ssl-config-generator/
 cert_location: /etc/ssl/certs/

--- a/scripts/categories.rb
+++ b/scripts/categories.rb
@@ -1,4 +1,7 @@
-#!/usr/bin/ruby
+# copyright: 2018, The Authors
+
+# encoding: UTF-8
+
 require 'discourse_api'
 require 'awesome_print'
 require 'json'
@@ -16,32 +19,27 @@ parent_categories = []
 # Get all the categories - an array of hashes
 categories = forum_client.categories
 categories.each do |category|
-  if category['has_children']
-    parent_categories.push(category['id'])
-    # Get all the  categories with this parent_id
-    print "#{category['name']} has children \n"
-  end
+  parent_categories.push(category['id']) unless category['has_children'].nil?
 end
-
 # Get the seeds
 Dir.glob("#{seeds_path}/*.yml").each do |file|
-    new_category = YAML.load_file(file)
-    new_category.each do |category|
-        print category['name'] + "\n"
-        args = { name: category['name'], 
-                        color: category['color'],
-                        text_color: category['text_color'],
-                        description: category['description'],
-                        # permissions: category['permissions'],
-                        slug: category['slug'],
-                        parent_category_id: category['parent_category_id']
-        }
-        begin
-          forum_client.create_category(args)
-        rescue => exception
-          puts "Exception #{exception}"
-        else
-          puts 'added a category'
-        end
+  new_category = YAML.load_file(file)
+  new_category.each do |category|
+    print category['name'] + "\n"
+    args = {
+      name: category['name'],
+      color: category['color'],
+      text_color: category['text_color'],
+      description: category['description'],
+      # permissions: category['permissions'],
+      slug: category['slug'],
+      parent_category_id: category['parent_category_id']
+    }
+    begin
+      forum_client.create_category(args)
+    rescue StandardError => exception
+      puts "Exception #{exception}"
     end
+    puts 'added a category'
+  end
 end

--- a/scripts/categories.rb
+++ b/scripts/categories.rb
@@ -8,7 +8,6 @@ require 'yaml'
 seeds_path = '../files/forum-data/categories/'
 forum_client = DiscourseApi::Client.new('https://community.egi.eu')
 secrets = YAML.load_file('../files/secrets.yml')
-# seed_categories = JSON.parse(File.read('../files/forum-data/categories/categories.json'))
 forum_client.api_key = secrets['api_key']
 forum_client.api_username = 'brucellino'
 # Create an array that will hold the parent category ids
@@ -17,11 +16,11 @@ parent_categories = []
 # Get all the categories - an array of hashes
 categories = forum_client.categories
 categories.each do |category|
-    if category['has_children']
-        parent_categories.push(category['id'])
-        # Get all the  categories with this parent_id
-        print "#{category['name']} has children \n"
-    end
+  if category['has_children']
+    parent_categories.push(category['id'])
+    # Get all the  categories with this parent_id
+    print "#{category['name']} has children \n"
+  end
 end
 
 # Get the seeds
@@ -29,8 +28,7 @@ Dir.glob("#{seeds_path}/*.yml").each do |file|
     new_category = YAML.load_file(file)
     new_category.each do |category|
         print category['name'] + "\n"
-        args = {
-                        name: category['name'], 
+        args = { name: category['name'], 
                         color: category['color'],
                         text_color: category['text_color'],
                         description: category['description'],
@@ -39,12 +37,11 @@ Dir.glob("#{seeds_path}/*.yml").each do |file|
                         parent_category_id: category['parent_category_id']
         }
         begin
-            forum_client.create_category(args)
+          forum_client.create_category(args)
         rescue => exception
-            puts "Exception #{exception}"
+          puts "Exception #{exception}"
         else
-            puts "added a category"
+          puts 'added a category'
         end
     end
 end
-

--- a/tests/README.md
+++ b/tests/README.md
@@ -26,11 +26,9 @@ We break up the tests into a few profiles
 
 We use the [Dev-Sec SSH baseline profile](https://github.com/dev-sec/ssh-baseline) for testing ssh configuration: 
 
+```bash
+inspec exec -t ssh://<username>@<forum_hostname> https://github.com/dev-sec/ssh-baseline
 ```
-inspec exec https://github.com/dev-sec/ssh-baseline
-```
-
-
 
 ### NGINX Hardening
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -24,6 +24,14 @@ We break up the tests into a few profiles
 
 ### SSH Hardening
 
+We use the [Dev-Sec SSH baseline profile](https://github.com/dev-sec/ssh-baseline) for testing ssh configuration: 
+
+```
+inspec exec https://github.com/dev-sec/ssh-baseline
+```
+
+
+
 ### NGINX Hardening
 
 ## Content

--- a/tests/content/categories/controls/categories.rb
+++ b/tests/content/categories/controls/categories.rb
@@ -1,20 +1,22 @@
-# encoding: utf-8
 # copyright: 2018, The Authors
+
+# encoding: UTF-8
+
 title 'categories'
 data = yaml(content: inspec.profile.file('categories.yml')).params
-    
+
 control 'category list' do
-    title 'Seed Categories'
-    desc 'Seed the categories with predetermined structure'
-    tag 'http'
-    
-    describe http('https://community.egi.eu/categories.json', method: 'GET') do
-        its('status') { should cmp 200 }
-        its('body') { should be }
-        its('body') { should include 'category_list'}
-        data['categories'].each do |category|
-            its('body') { should include category['name'] }
-            its('body') { should include category['slug']}
-        end
+  title 'Seed Categories'
+  desc 'Seed the categories with predetermined structure'
+  tag 'http'
+
+  describe http('https://community.egi.eu/categories.json', method: 'GET') do
+    its('status') { should cmp 200 }
+    its('body') { should be }
+    its('body') { should include 'category_list' }
+    data['categories'].each do |category|
+      its('body') { should include category['name'] }
+      its('body') { should include category['slug'] }
     end
+  end
 end

--- a/vars/community.egi.eu.yml
+++ b/vars/community.egi.eu.yml
@@ -1,0 +1,204 @@
+---
+## SSH stuff
+# true if IPv6 is needed
+network_ipv6_enable: false              # sshd + ssh
+# true if sshd should be started and enabled
+ssh_server_enabled: true               # sshd
+# true if DNS resolutions are needed, look up the remote host name, defaults to false from 6.8, see: http://www.openssh.com/txt/release-6.8
+ssh_use_dns: false                      # sshd
+# true or value if compression is needed
+ssh_compression: false                  # sshd
+# For which components (client and server) to generate the configuration for. 
+# Can be useful when running against a client without an SSH server.
+ssh_client_hardening: true          # ssh
+ssh_server_hardening: true          # sshd
+# true if CBC for ciphers is required. 
+# This is usually only necessary, if older M2M mechanism need to communicate with SSH, that don't have any of the configured secure ciphers enabled. 
+# CBC is a weak alternative. 
+# Anything weaker should be avoided and is thus not available.
+ssh_client_cbc_required: false          # ssh
+ssh_server_cbc_required: false          # sshd
+# true if weaker HMAC mechanisms are required. 
+# This is usually only necessary, if older M2M mechanism need to communicate with SSH, that don't have any of the configured secure HMACs enabled.
+ssh_client_weak_hmac: false             # ssh
+ssh_server_weak_hmac: false             # sshd
+# true if weaker Key-Exchange (KEX) mechanisms are required. 
+# This is usually only necessary, if older M2M mechanism need to communicate with SSH, that don't have any of the configured secure KEXs enabled.
+ssh_client_weak_kex: false              # ssh
+ssh_server_weak_kex: false              # sshd
+# If true, password login is allowed
+ssh_client_password_login: false          # ssh
+ssh_server_password_login: false          # sshd
+# ports on which ssh-server should listen
+ssh_server_ports: ['22']      # sshd
+# port to which ssh-client should connect
+ssh_client_port: '22'         # ssh
+# one or more ip addresses, to which ssh-server should listen to. 
+# Default is empty, but should be configured for security reasons!
+ssh_listen_to: ['0.0.0.0']    # sshd
+# Host keys to look for when starting sshd.
+ssh_host_key_files: []  # sshd
+# Specifies  the  maximum  number  of authentication attempts permitted per connection.  
+# Once the number of failures reaches half this value, additional failures are logged.
+ssh_max_auth_retries: 2
+ssh_client_alive_interval: 600          # sshd
+ssh_client_alive_count: 3               # sshd
+# Allow SSH Tunnels
+ssh_permit_tunnel: false
+ssh_remote_hosts: []
+# false to disable root login altogether. Set to true to allow root to login via key-based mechanism.
+ssh_allow_root_with_key: true          # sshd
+# false to disable TCP Forwarding. Set to true to allow TCP Forwarding.
+ssh_allow_tcp_forwarding: false         # sshd
+# false to disable binding forwarded ports to non-loopback addresses. Set to true to force binding on wildcard address.
+# Set to 'clientspecified' to allow the client to specify which address to bind to.
+ssh_gateway_ports: false                # sshd
+# false to disable Agent Forwarding. Set to true to allow Agent Forwarding.
+ssh_allow_agent_forwarding: true       # sshd
+# false to disable pam authentication.
+ssh_use_pam: true      # sshd
+# false to disable google 2fa authentication
+ssh_google_auth: false # sshd
+# if specified, login is disallowed for user names that match one of the patterns.
+ssh_deny_users: ''      # sshd
+# if specified, login is allowed only for user names that match one of the patterns.
+ssh_allow_users: ''      # sshd
+# if specified, login is disallowed for users whose primary group or supplementary group list matches one of the patterns.
+ssh_deny_groups: ''      # sshd
+# if specified, login is allowed only for users whose primary group or supplementary group list matches one of the patterns.
+ssh_allow_groups: ''      # sshd
+# change default file that contains the public keys that can be used for user authentication.
+ssh_authorized_keys_file: ''      # sshd
+# false to disable printing of the MOTD
+ssh_print_motd: false      # sshd
+# false to disable display of last login information
+ssh_print_last_log: false    # sshd
+# false to disable serving /etc/ssh/banner.txt before authentication is allowed
+ssh_banner: false # sshd
+# false to disable distribution version leakage during initial protocol handshake
+ssh_print_debian_banner: false # sshd (Debian OS family only)
+# true to enable sftp configuration
+sftp_enabled: false
+# change default sftp chroot location
+sftp_chroot_dir: /home/%u
+# enable experimental client roaming
+ssh_client_roaming: false
+# list of hashes (containing user and rules) to generate Match User blocks for.
+ssh_server_match_user: false            # sshd
+# list of hashes (containing group and rules) to generate Match Group blocks for.
+ssh_server_match_group: false           # sshd
+ssh_server_permit_environment_vars: false
+ssh_ps53: 'yes'
+ssh_ps59: 'sandbox'
+ssh_macs: []
+ssh_ciphers: []
+ssh_kex: []
+ssh_macs_53_default:
+  - hmac-ripemd160
+  - hmac-sha1
+ssh_macs_59_default:
+  - hmac-sha2-512
+  - hmac-sha2-256
+  - hmac-ripemd160
+ssh_macs_59_weak: "{{ ssh_macs_59_default + ['hmac-sha1'] }}"
+ssh_macs_66_default:
+  - hmac-sha2-512-etm@openssh.com
+  - hmac-sha2-256-etm@openssh.com
+  - umac-128-etm@openssh.com
+  - hmac-sha2-512
+  - hmac-sha2-256
+ssh_macs_76_default:
+  - hmac-sha2-512-etm@openssh.com
+  - hmac-sha2-256-etm@openssh.com
+  - umac-128-etm@openssh.com
+  - hmac-sha2-512
+  - hmac-sha2-256
+ssh_macs_66_weak: "{{ ssh_macs_66_default + ['hmac-sha1'] }}"
+ssh_ciphers_53_default:
+  - aes256-ctr
+  - aes192-ctr
+  - aes128-ctr
+ssh_ciphers_53_weak: "{{ ssh_ciphers_53_default + ['aes256-cbc', 'aes192-cbc', 'aes128-cbc'] }}"
+ssh_ciphers_66_default:
+  - chacha20-poly1305@openssh.com
+  - aes256-gcm@openssh.com
+  - aes128-gcm@openssh.com
+  - aes256-ctr
+  - aes192-ctr
+  - aes128-ctr
+ssh_ciphers_66_weak: "{{ ssh_ciphers_66_default + ['aes256-cbc', 'aes192-cbc', 'aes128-cbc'] }}"
+ssh_kex_59_default:
+  - diffie-hellman-group-exchange-sha256
+ssh_kex_59_weak: "{{ ssh_kex_59_default + ['diffie-hellman-group14-sha1', 'diffie-hellman-group-exchange-sha1', 'diffie-hellman-group1-sha1'] }}"
+ssh_kex_66_default:
+  - curve25519-sha256@libssh.org
+  - diffie-hellman-group-exchange-sha256
+ssh_kex_66_weak: "{{ ssh_kex_66_default + ['diffie-hellman-group14-sha1', 'diffie-hellman-group-exchange-sha1', 'diffie-hellman-group1-sha1'] }}"
+# directory where to store ssh_password policy
+ssh_custom_selinux_dir: '/etc/selinux/local-policies'
+sshd_moduli_minimum: 2048
+# disable ChallengeResponseAuthentication
+ssh_challengeresponseauthentication: false
+# a list of public keys that are never accepted by the ssh server
+ssh_server_revoked_keys: []
+
+## NGINX stuff
+  # Love https://mozilla.github.io/server-side-tls/ssl-config-generator/
+cert_location: /etc/ssl/certs/
+nginx_sites:
+  http:
+    -  listen      80 default
+    - server_name community.egi.eu
+## redirect http to https ##
+    - return      301 https://$server_name$request_uri
+  https:
+     - listen 443 
+     - listen [::]:443
+     - ssl on
+     - ssl_certificate    /etc/ssl/certs/server.crt
+     - ssl_certificate_key    /etc/ssl/certs/server.key
+     - ssl_session_timeout 1d
+     - ssl_protocols TLSv1.2
+     - ssl_ciphers  'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256'
+     - ssl_prefer_server_ciphers on
+     - ssl_session_cache shared:SSL:10m
+     - add_header Strict-Transport-Security max-age=15768000
+     - server_name community.egi.eu
+     - | 
+            location / { 
+                proxy_pass http://unix:/var/discourse/shared/standalone/nginx.http.sock:; 
+                proxy_set_header Host $http_host; proxy_http_version 1.1; 
+                proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; 
+                proxy_set_header X-Forwarded-Proto $scheme; 
+                }
+# Discourse stuff
+#discourse_hostname:
+developer_emails: 'brucellino@gmail.com'
+smtp_address: smtp-relay.gmail.com
+# smtp username should be empty for the un-authenticated relay
+smtp_username: ""
+smtp_port: 587
+discourse_templates:
+  - postgres
+  - redis
+  - web
+  - sshd
+  - web.ratelimited
+  - web.socketed
+
+discourse_plugins:
+  - name: Discourse Data Explorer
+    description: Allows better querying of Discourse database
+    url: https://github.com/discourse/discourse-data-explorer.git
+  - name: "Discourse Solved ✔"
+    description: "Allows you to mark posts as solutions"
+    url: https://github.com/discourse/discourse-solved.git
+  - name: Slack plugin
+    description: "Discourse to slack plugin"
+    url: https://github.com/bernd/discourse-slack-plugin.git
+  - name: Checklist
+    description: "For when you need to render checklists"
+    url: https://github.com/cpradio/discourse-plugin-checklist
+  - name: OAuth2 provider
+    description: "Enable OAuth2 identity provider configuration"
+    url: https://github.com/discourse/discourse-oauth2-basic


### PR DESCRIPTION
# Summary 

![6445345253f8906082486c8c48b846bc](https://user-images.githubusercontent.com/2115428/39358918-27d7e24a-4a18-11e8-9c42-0c60c95d155b.jpg)

ONLY THE FEARLESS SHALL PASS 

----

**Related issue :** #7 

This PR applies the [dev-sec.ssh-hardening](https://github.com/dev-sec/ssh-hardening) role to the machine to make our SSH impervious to baddies. Well... almost: 

  - root access with ssh key is kept (I will add a discourse ssh user and disable root access later). There is no password access, so it's not insanely insecure. 
  - There are three tests that are failing (see #7), but these are acceptable.





